### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "macos-latest" ]
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 in progress
 ===========
+- Add support for Python 3.10
 
 
 2022-08-03 0.13.0

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Communications",
         "Topic :: Internet",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
What the title says. It should fail unless https://github.com/brainsik/json-store/pull/7 will have been merged and see a release.